### PR TITLE
[Merged by Bors] - Handle client shutdown cleanly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,8 @@ dependencies = [
 [[package]]
 name = "babilado-types"
 version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6596dbc02dc932f0c0717f129fa9fc4c36e48f753fa8c67605fbc4a9fad33b0c"
 dependencies = [
  "oorandom",
  "serde",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use babilado_types::{Event, User};
+use jsonl::ReadError;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::io::{self, BufReader};
@@ -37,15 +38,23 @@ struct Client {
     address: SocketAddr,
 }
 
+#[derive(Debug)]
+enum ClientEvent {
+    Add(Client),
+    Remove(SocketAddr),
+}
+
 async fn forward_events(
-    mut clients_rx: mpsc::Receiver<Client>,
+    mut clients_rx: mpsc::Receiver<ClientEvent>,
     mut events_rx: mpsc::Receiver<(Event, SocketAddr)>,
 ) -> anyhow::Result<()> {
     let mut clients = Vec::new();
 
     loop {
         select! {
-            Some(client) = clients_rx.recv() => clients.push(client),
+            Some(client_event) = clients_rx.recv() => {
+                handle_client_event(client_event, &mut clients)
+            },
             Some((event, event_origin)) = events_rx.recv() => {
                 for Client { writer, address } in &mut clients {
                     if *address == event_origin {
@@ -60,10 +69,27 @@ async fn forward_events(
     }
 }
 
+fn handle_client_event(client_event: ClientEvent, clients: &mut Vec<Client>) {
+    match client_event {
+        ClientEvent::Add(client) => clients.push(client),
+        ClientEvent::Remove(address) => {
+            let idx = clients
+                .iter()
+                .enumerate()
+                .find_map(
+                    |(idx, Client { address: a, .. })| if *a == address { Some(idx) } else { None },
+                )
+                .unwrap();
+
+            clients.remove(idx);
+        }
+    }
+}
+
 async fn handle_stream(
     stream: io::Result<TcpStream>,
     users: Arc<Mutex<Vec<User>>>,
-    clients_tx: mpsc::Sender<Client>,
+    clients_tx: mpsc::Sender<ClientEvent>,
     events_tx: mpsc::Sender<(Event, SocketAddr)>,
 ) -> anyhow::Result<()> {
     let mut stream = stream?;
@@ -86,16 +112,25 @@ async fn handle_stream(
     let (read_half, write_half) = stream.into_split();
 
     clients_tx
-        .send(Client {
+        .send(ClientEvent::Add(Client {
             writer: write_half,
             address,
-        })
+        }))
         .await
         .unwrap();
 
     let mut read_half = BufReader::new(read_half);
+
     loop {
-        let event: Event = jsonl::read(&mut read_half).await?;
+        let event: Event = match jsonl::read(&mut read_half).await {
+            Ok(e) => e,
+            Err(ReadError::Eof) => {
+                clients_tx.send(ClientEvent::Remove(address)).await.unwrap();
+                return Ok(());
+            }
+            Err(e) => return Err(e.into()),
+        };
+
         events_tx.send((event, address)).await.unwrap();
     }
 }


### PR DESCRIPTION
Previously the `ReadError::Eof` error in `handle_stream` was unhandled, which meant that that same error occurred the next time an event occurred and was forwarded to the closed client stream (`forward_events`). This error led to the function returning, dropping `events_rx`. This in turn led to a panic the next time an event occurred , since the only receiver of `events_tx` had been dropped.